### PR TITLE
Fixes "MSBUILD : error MSB1008: Only one project can be specified"

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function msbuild(options, execFile) {
     var args = buildArguments(options);
 
     var executeFunc = execFile ? execFile : exec;
-    var cp = executeFunc([executable, file.path, args].join(' '), {}, function(err) {
+    var cp = executeFunc([executable, '"' + file.path + '"', args].join(' '), {}, function(err) {
       if (err) {
         gutil.log(gutil.colors.red('Build failed!'));
         return;


### PR DESCRIPTION
..."

Wrapped double quotes around file.path. to fix error below which was
caused by spaces in the path to the file.

[gulp] Starting 'default'...
[gulp] Finished 'default' after 5.44 ms
MSBUILD : error MSB1008: Only one project can be specified.
Switch: Studio

For switch syntax, type "MSBuild /help"
[gulp] Build failed!
