### PR TITLE
Wait until the build is complete before streaming

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,17 @@ module.exports = function(options) {
   options = mergeOptionsWithDefaults(options);
 
   var stream = through.obj(function(file, enc, callback) {
+    var self = this;
     if (file.isNull()) {
-      this.push(file);
+      self.push(file);
       return callback();
     }
 
-    this.push(file);
-    return msbuildRunner.startMsBuildTask(options, file, callback);
+    return msbuildRunner.startMsBuildTask(options, file, function(err) {
+        if (err) return callback(err);
+        self.push(file);
+        return callback();
+    });
   });
 
   return stream;


### PR DESCRIPTION
Previously it would instantly pass on the file to the next `.pipe`. With this change, the file won't get passed along until the build finishes. If it fails the file will not get passed.
