### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var gulp = require("gulp");
 var msbuild = require("gulp-msbuild");
 
 gulp.task("default", function() {
-	gulp.src("./project.sln")
+	return gulp.src("./project.sln")
 		.pipe(msbuild());
 });
 ```
@@ -35,7 +35,7 @@ var gulp = require("gulp");
 var msbuild = require("gulp-msbuild");
 
 gulp.task("default", function() {
-	gulp.src("./project.sln")
+	return gulp.src("./project.sln")
 		.pipe(msbuild({
 			targets: ['Clean', 'Build'],
 			toolsVersion: 3.5


### PR DESCRIPTION
Some folks were still having issues with the gulp task completing before the build was finished (#8). I noticed the examples had a small error.

Gulp needs to know what the task is doing which can be accomplished several ways depending on the task in question. For streams, you simply return the stream object.

[Running tasks in series](https://github.com/gulpjs/gulp/blob/master/docs/recipes/running-tasks-in-series.md)