### PR TITLE
- Added architecture option to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ properties: { Configuration: 'Debug' }
 
 **Possible Values:** 1.0, 1.1, 2.0, 3.5, 4.0, 12.0, 14.0
 
+#### architecture
+
+> Specify the Architecture
+
+**Default:** Auto-detected
+
+**Possible Values:** x86, x64
+
+**Example:**
+```javascript
+msbuild({ architecutre: 'x86' })
+```
+
 #### properties
 
 > Specify Custom Build Properties


### PR DESCRIPTION
This adds an additional note to the documentation about the "architecture" option.

Our build server is x64, but we have a legacy project that must be built using the x86 version of the tools. (It's a .NET Compact Framework project. The needed properties and targets only exist in the `Framework\v3.5` folder, not in the `Framework64\v3.5` folder.) The following worked for us, it just isn't documented:

msbuild({
  architecture: 'x86',
  toolsVersion: 3.5
})