### PR TITLE
Fixing spelling of architecture option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ properties: { Configuration: 'Debug' }
 
 **Example:**
 ```javascript
-msbuild({ architecutre: 'x86' })
+msbuild({ architecture: 'x86' })
 ```
 
 #### properties


### PR DESCRIPTION
Documentation spelling fix