### PR TITLE
Omit `/maxcpucount` argument when using xbuild (fixes #22)

### DIFF
--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -24,8 +24,9 @@ module.exports.buildArguments = function(options) {
     args.push('/clp:' + options.consoleLoggerParameters);
   }
 
-  if (options.maxcpucount >= 0) {
-    if (options.maxcpucount == 0) {
+  // xbuild does not support the `maxcpucount` argument and throws if provided
+  if (options.maxcpucount >= 0 && options.msbuildPath !== 'xbuild') {
+    if (options.maxcpucount === 0) {
       gutil.log(gutil.colors.cyan('Using automatic maxcpucount'));
       args.push('/maxcpucount');
     } else {

--- a/test/msbuild-command-builder.js
+++ b/test/msbuild-command-builder.js
@@ -68,6 +68,15 @@ describe('msbuild-command-builder', function () {
       expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /property:Configuration="Release"');
     });
 
+    it('should build arguments excluding maxcpucount when using xbuild', function () {
+      var options = defaults;
+      options.maxcpucount = 4;
+      options.msbuildPath = 'xbuild';
+      var result = commandBuilder.buildArguments(options);
+
+      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /property:Configuration="Release"');
+    });
+
     it('should build arguments with custom properties', function () {
       var options = defaults;
       options.properties = { WarningLevel: 2 };


### PR DESCRIPTION
See #22.