### PR TITLE
Add support for /nodeReuse:False MSBuild command line parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ msbuild({ properties: { WarningLevel: 2 } })
 
 **Possible Values:** -1 (MSBuild Default), 0 (Automatic), > 0 (Concrete value)
 
+#### nodeReuse
+
+> Specify whether to enable or disable the re-use of MSBuild nodes
+
+**Default:** true = Nodes remain after the build finishes so that subsequent builds can use them
+
+**Possible Values:** true (MSBuild Default), false
+
 #### nologo
 
 > Suppress Startup Banner and Copyright Message of MSBuild

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -33,7 +33,8 @@ module.exports = {
     windir: process.env.WINDIR,
     msbuildPath: '',
     fileLoggerParameters: undefined,
-    consoleLoggerParameters: undefined
+    consoleLoggerParameters: undefined,
+    nodeResue: true
   }
 };
 

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -33,6 +33,10 @@ module.exports.buildArguments = function(options) {
     }
   }
 
+  if (options.nodeReuse === false) {
+      args.push('/nodeReuse:False')
+  }
+
   if (options.configuration) {
     options.properties = _.extend({
       'Configuration': options.configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-msbuild",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "msbuild plugin for gulp. Inspired by grunt-msbuild.",
   "keywords": [
     "gulpplugin",

--- a/test/msbuild-command-builder.js
+++ b/test/msbuild-command-builder.js
@@ -116,6 +116,14 @@ describe('msbuild-command-builder', function () {
 
       expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo "/clp:Verbosity=minimal" /maxcpucount /property:Configuration="Release"');
     });
+
+    it('should build arguments /nodeReuse:False when specified', function () {
+      var options = defaults;
+      options.nodeReuse = false;
+      var result = commandBuilder.buildArguments(options);
+
+      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /maxcpucount /nodeReuse:False /property:Configuration="Release"');
+    });
   });
 
 


### PR DESCRIPTION
If options.nodeReuse === false, MSBuild command line will have /nodeReuse:False argument.
If options.nodeReuse is not specified or is not equal false, the command line won't have
any /nodeReuse argument and the default value (true) will be used by MSBuild.