### PR TITLE
Run using child_process `spawn` rather than `exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,6 @@ gulp.task("default", function() {
 
 **Default:** false
 
-#### maxBuffer
-
-> Specifies the largest amount of data allowed on stdout or stderr - if this value is exceeded then the msbuild child process is killed.
-
-**Default:** 500*1024
-
 #### targets
 
 > Specify Build Targets

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -19,7 +19,6 @@ module.exports = {
     stdout: false,
     stderr: true,
     errorOnFail: false,
-    maxBuffer: 500 * 1024,
     logCommand: false,
     targets: ['Rebuild'],
     configuration: 'Release',

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -8,7 +8,7 @@ var PluginError = gutil.PluginError;
 
 module.exports.buildArguments = function(options) {
   var args = [];
-  args.push('"/target:' + options.targets.join(';') + '"');
+  args.push('/target:' + options.targets.join(';'));
   args.push('/verbosity:' + options.verbosity);
   args.push('/toolsversion:' + parseFloat(options.toolsVersion).toFixed(1));
 
@@ -17,15 +17,15 @@ module.exports.buildArguments = function(options) {
   }
 
   if (options.fileLoggerParameters) {
-    args.push('"/flp:' + options.fileLoggerParameters + '"');
+    args.push('/flp:' + options.fileLoggerParameters);
   }
 
   if (options.consoleLoggerParameters) {
-    args.push('"/clp:' + options.consoleLoggerParameters + '"');
+    args.push('/clp:' + options.consoleLoggerParameters);
   }
 
   if (options.loggerParameters) {
-    args.push('"/logger:' + options.loggerParameters + '"');
+    args.push('/logger:' + options.loggerParameters);
   }
 
   // xbuild does not support the `maxcpucount` argument and throws if provided
@@ -48,10 +48,10 @@ module.exports.buildArguments = function(options) {
   }
 
   for (var property in options.properties) {
-    args.push('/property:' + property + '="' + options.properties[property] + '"');
+    args.push('/property:' + property + '=' + options.properties[property]);
   }
 
-  return args.join(' ');
+  return args;
 };
 
 module.exports.construct = function(file, options) {
@@ -65,8 +65,9 @@ module.exports.construct = function(file, options) {
   }
 
   var args = this.buildArguments(options);
-  var executable = '"' + path.normalize(options.msbuildPath) + '"';
-  var filePath = ' "' + file.path + '" ';
 
-  return executable + filePath + args;
+  return {
+    executable: path.normalize(options.msbuildPath),
+    args: [file.path].concat(args)
+  };
 };

--- a/lib/msbuild-runner.js
+++ b/lib/msbuild-runner.js
@@ -34,14 +34,24 @@ module.exports.startMsBuildTask = function (options, file, callback) {
   });
 
   cp.on('close', function (code, signal) {
-    if (code != 0) {
-      gutil.log(gutil.colors.red('Build failed with code ' + code + '!'));
+    if (code === 0) {
+      gutil.log(gutil.colors.cyan('Build complete!'));
+    } else {
+      var msg;
+
+      if (code != null) {
+        // Exited normally, but failed.
+        msg = 'Build failed with code ' + code + '!';
+      } else {
+        // Killed by parent process.
+        msg = 'Build killed with signal ' + signal + '!';
+      }
+
+      gutil.log(gutil.colors.red(msg));
 
       if (options.errorOnFail) {
-        return callback({ code: code, signal: signal });
+        return callback(new Error(msg));
       }
-    } else {
-      gutil.log(gutil.colors.cyan('Build complete!'));
     }
 
     return callback();

--- a/lib/msbuild-runner.js
+++ b/lib/msbuild-runner.js
@@ -8,16 +8,37 @@ module.exports.startMsBuildTask = function (options, file, callback) {
   var command = commandBuilder.construct(file, options);
 
   if (options.logCommand) {
-    gutil.log("Using msbuild command: " + command);
+    gutil.log('Using msbuild command:', command.executable, command.args.join(' '));
   }
 
-  var execOptions = { maxBuffer: options.maxBuffer };
-  var cp = childProcess.exec(command, execOptions, function (err) {
+  var io = ['ignore'];
+
+  io.push(options.stdout ? process.stdout : 'ignore');
+  io.push(options.stderr ? process.stderr : 'ignore');
+
+  var spawnOptions = { stdio: io };
+
+  var cp = childProcess.spawn(command.executable, command.args, spawnOptions);
+
+  cp.on('error', function (err) {
     if (err) {
       gutil.log(err);
       gutil.log(gutil.colors.red('Build failed!'));
+
       if (options.errorOnFail) {
         return callback(err);
+      }
+    }
+
+    return callback();
+  });
+
+  cp.on('close', function (code, signal) {
+    if (code != 0) {
+      gutil.log(gutil.colors.red('Build failed with code ' + code + '!'));
+
+      if (options.errorOnFail) {
+        return callback({ code: code, signal: signal });
       }
     } else {
       gutil.log(gutil.colors.cyan('Build complete!'));
@@ -25,13 +46,4 @@ module.exports.startMsBuildTask = function (options, file, callback) {
 
     return callback();
   });
-
-  if (options.stdout && cp) {
-    cp.stdout.pipe(process.stdout);
-  }
-
-  if (options.stderr && cp) {
-    cp.stderr.pipe(process.stderr);
-  }
 };
-

--- a/test/msbuild-command-builder.js
+++ b/test/msbuild-command-builder.js
@@ -26,7 +26,7 @@ describe('msbuild-command-builder', function () {
     it('should build arguments with default options', function () {
       var result = commandBuilder.buildArguments(defaults);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /maxcpucount /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Configuration=Release']);
     });
 
     it('should build arguments without nologo', function () {
@@ -34,14 +34,14 @@ describe('msbuild-command-builder', function () {
       options.nologo = undefined;
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /maxcpucount /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/maxcpucount', '/property:Configuration=Release']);
     });
 
     it('should build arguments with maxcpucount by default', function () {
       var options = defaults;
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /maxcpucount /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Configuration=Release']);
     });
 
     it('should build arguments with maxcpucount equal zero', function () {
@@ -49,7 +49,7 @@ describe('msbuild-command-builder', function () {
       options.maxcpucount = 0;
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /maxcpucount /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Configuration=Release']);
     });
 
     it('should build arguments with positive maxcpucount', function () {
@@ -57,7 +57,7 @@ describe('msbuild-command-builder', function () {
       options.maxcpucount = 4;
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /maxcpucount:4 /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount:4', '/property:Configuration=Release']);
     });
 
     it('should build arguments with negative maxcpucount', function () {
@@ -65,7 +65,7 @@ describe('msbuild-command-builder', function () {
       options.maxcpucount = -1;
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/property:Configuration=Release']);
     });
 
     it('should build arguments excluding maxcpucount when using xbuild', function () {
@@ -74,7 +74,7 @@ describe('msbuild-command-builder', function () {
       options.msbuildPath = 'xbuild';
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/property:Configuration=Release']);
     });
 
     it('should build arguments with custom properties', function () {
@@ -82,7 +82,7 @@ describe('msbuild-command-builder', function () {
       options.properties = { WarningLevel: 2 };
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /maxcpucount /property:Configuration="Release" /property:WarningLevel="2"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Configuration=Release', '/property:WarningLevel=2']);
     });
 
     it('should add Configuration Property when Configuration-Option is specified', function () {
@@ -90,7 +90,7 @@ describe('msbuild-command-builder', function () {
       options.configuration = 'Debug';
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /maxcpucount /property:Configuration="Debug"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Configuration=Debug']);
     });
 
     it('should use Configuration Property in the custom properties list when specified', function () {
@@ -98,7 +98,7 @@ describe('msbuild-command-builder', function () {
       options.properties = { Configuration: 'Debug' };
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /maxcpucount /property:Configuration="Debug"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Configuration=Debug']);
     });
 
     it('should use fileLoggerParameters when specified', function () {
@@ -106,7 +106,7 @@ describe('msbuild-command-builder', function () {
       options.fileLoggerParameters = 'LogFile=Build.log';
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo "/flp:LogFile=Build.log" /maxcpucount /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/flp:LogFile=Build.log', '/maxcpucount', '/property:Configuration=Release']);
     });
 
     it('should use consoleLoggerParameters when specified', function () {
@@ -114,7 +114,7 @@ describe('msbuild-command-builder', function () {
       options.consoleLoggerParameters = 'Verbosity=minimal';
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo "/clp:Verbosity=minimal" /maxcpucount /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/clp:Verbosity=minimal', '/maxcpucount', '/property:Configuration=Release']);
     });
 
     it('should use loggerParameters when specified', function () {
@@ -122,7 +122,7 @@ describe('msbuild-command-builder', function () {
       options.loggerParameters = 'XMLLogger,./MyLogger.dll;OutputAsHTML';
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo "/logger:XMLLogger,./MyLogger.dll;OutputAsHTML" /maxcpucount /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/logger:XMLLogger,./MyLogger.dll;OutputAsHTML', '/maxcpucount', '/property:Configuration=Release']);
     });
 
     it('should build arguments /nodeReuse:False when specified', function () {
@@ -130,7 +130,7 @@ describe('msbuild-command-builder', function () {
       options.nodeReuse = false;
       var result = commandBuilder.buildArguments(options);
 
-      expect(result).to.be.equal('"/target:Rebuild" /verbosity:normal /toolsversion:4.0 /nologo /maxcpucount /nodeReuse:False /property:Configuration="Release"');
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/nodeReuse:False', '/property:Configuration=Release']);
     });
   });
 
@@ -161,7 +161,7 @@ describe('msbuild-command-builder', function () {
       var command = commandBuilder.construct({}, options);
 
       expect(msbuildFinder.find).to.not.have.been.calledWith(options);
-      expect(command).to.be.match(/here(.+)/);
+      expect(command.executable).to.equal('here');
     });
 
     it('should construct a valid command', function () {
@@ -169,7 +169,8 @@ describe('msbuild-command-builder', function () {
       options.msbuildPath = 'here';
       var command = commandBuilder.construct({ path: 'test.sln' }, options);
 
-      expect(command).to.be.match(/"here" "test.sln" (.+)/);
+      expect(command.executable).to.equal('here');
+      expect(command.args).to.contain('test.sln');
     });
   });
 

--- a/test/msbuild-runner.js
+++ b/test/msbuild-runner.js
@@ -16,64 +16,101 @@ var msbuildRunner = require('../lib/msbuild-runner');
 
 var defaults;
 
-var execCallbackArg;
+var events;
+
+function simulateEvent(name, data) {
+  events.push({ name: name, data: data });
+}
 
 describe('msbuild-runner', function () {
 
   beforeEach(function () {
     defaults = JSON.parse(JSON.stringify(constants.DEFAULTS));
+    events = [];
 
-    this.sinon.stub(childProcess, 'exec', function (command, options, callback) {
-      process.nextTick(function() { callback(execCallbackArg); });
+    function spawn(command, args, options) {
+      var listeners = {};
 
-      var stream = new Stream();
-      stream.pipe = function() {};
+      process.nextTick(function() {
+        events.forEach(function(e) {
+          listeners[e.name](e.data);
+        });
+      });
 
       return {
-        stdout: stream,
-        stderr: stream
+        on: function(name, handler) {
+          listeners[name] = handler;
+        }
       };
-    });
+    }
 
-    this.sinon.stub(commandBuilder, 'construct').returns('msbuild /nologo');
+    this.sinon.stub(childProcess, 'spawn', spawn);
+    this.sinon.stub(commandBuilder, 'construct').returns({ executable: 'msbuild', args: ['/nologo'] });
     this.sinon.stub(gutil, 'log');
   });
 
   it('should execute the msbuild command', function (done) {
     defaults.stdout = true;
+
+    simulateEvent('close', 0);
+
     msbuildRunner.startMsBuildTask(defaults, {}, function () {
       expect(gutil.log).to.have.been.calledWith(gutil.colors.cyan('Build complete!'));
       done();
     });
 
-    expect(childProcess.exec).to.have.been.calledWith('msbuild /nologo', { maxBuffer: defaults.maxBuffer });
+    expect(childProcess.spawn).to.have.been.calledWith('msbuild', ['/nologo']);
   });
 
   it('should log the command when the logCommand option is set', function(done) {
     defaults.logCommand = true;
+
+    simulateEvent('close', 0);
+
     msbuildRunner.startMsBuildTask(defaults, {}, function () {
-      expect(gutil.log).to.have.been.calledWith('Using msbuild command: msbuild /nologo');
+      expect(gutil.log).to.have.been.calledWith('Using msbuild command:', 'msbuild', '/nologo');
       done();
     });
   });
 
-  it('should log the error when the msbuild command failed', function (done) {
-    execCallbackArg = 'test';
+  it('should log an error message when the msbuild command failed', function (done) {
+    simulateEvent('close', 1);
 
     msbuildRunner.startMsBuildTask(defaults, {}, function () {
-      expect(gutil.log).to.have.been.calledWith(execCallbackArg);
+      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('Build failed with code 1!'));
+      done();
+    });
+  });
+
+  it('should log an error message and return the error in the callback when the msbuild command failed', function (done) {
+    defaults.errorOnFail = true;
+
+    simulateEvent('close', 1);
+
+    msbuildRunner.startMsBuildTask(defaults, {}, function (err) {
+      expect(err.code).to.be.equal(1);
+      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('Build failed with code 1!'));
+      done();
+    });
+  });
+
+  it('should log an error message when the spawned process experienced an error', function (done) {
+    simulateEvent('error', 'broken');
+
+    msbuildRunner.startMsBuildTask(defaults, {}, function () {
+      expect(gutil.log).to.have.been.calledWith('broken');
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('Build failed!'));
       done();
     });
   });
 
-  it('should log the error and return the error in the callback when the msbuild command failed', function (done) {
+  it('should log an error and return the error in the callback when the spawned process experienced an error', function (done) {
     defaults.errorOnFail = true;
-    execCallbackArg = 'test';
+
+    simulateEvent('error', 'broken');
 
     msbuildRunner.startMsBuildTask(defaults, {}, function (err) {
-      expect(err).to.be.equal(execCallbackArg);
-      expect(gutil.log).to.have.been.calledWith(execCallbackArg);
+      expect(err).to.be.equal('broken');
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('Build failed!'));
       done();
     });


### PR DESCRIPTION
This PR modifies gulp-msbuild so that it will execute MSBuild using `child_process.spawn` instead of `child_process.exec`.

There are a few benefits to doing so:
- MSBuild's console message coloring is preserved (see
  https://groups.google.com/forum/#!topic/nodejs/t8dPnfqVl6U for background)
- The `maxBuffer` option is no longer needed
- Arguments supplied to MSBuild no longer need to be escaped