### PR TITLE
Clarify source of log messages

### DIFF
--- a/lib/msbuild-runner.js
+++ b/lib/msbuild-runner.js
@@ -8,7 +8,7 @@ module.exports.startMsBuildTask = function (options, file, callback) {
   var command = commandBuilder.construct(file, options);
 
   if (options.logCommand) {
-    gutil.log('Using msbuild command:', command.executable, command.args.join(' '));
+    gutil.log(gutil.colors.cyan('Using MSBuild command:'), command.executable, command.args.join(' '));
   }
 
   var io = ['ignore'];
@@ -23,7 +23,7 @@ module.exports.startMsBuildTask = function (options, file, callback) {
   cp.on('error', function (err) {
     if (err) {
       gutil.log(err);
-      gutil.log(gutil.colors.red('Build failed!'));
+      gutil.log(gutil.colors.red('MSBuild failed!'));
 
       if (options.errorOnFail) {
         return callback(err);
@@ -35,16 +35,16 @@ module.exports.startMsBuildTask = function (options, file, callback) {
 
   cp.on('close', function (code, signal) {
     if (code === 0) {
-      gutil.log(gutil.colors.cyan('Build complete!'));
+      gutil.log(gutil.colors.cyan('MSBuild complete!'));
     } else {
       var msg;
 
       if (code != null) {
         // Exited normally, but failed.
-        msg = 'Build failed with code ' + code + '!';
+        msg = 'MSBuild failed with code ' + code + '!';
       } else {
         // Killed by parent process.
-        msg = 'Build killed with signal ' + signal + '!';
+        msg = 'MSBuild killed with signal ' + signal + '!';
       }
 
       gutil.log(gutil.colors.red(msg));

--- a/test/msbuild-runner.js
+++ b/test/msbuild-runner.js
@@ -55,7 +55,7 @@ describe('msbuild-runner', function () {
     simulateEvent('close', 0);
 
     msbuildRunner.startMsBuildTask(defaults, {}, function () {
-      expect(gutil.log).to.have.been.calledWith(gutil.colors.cyan('Build complete!'));
+      expect(gutil.log).to.have.been.calledWith(gutil.colors.cyan('MSBuild complete!'));
       done();
     });
 
@@ -68,7 +68,7 @@ describe('msbuild-runner', function () {
     simulateEvent('close', 0);
 
     msbuildRunner.startMsBuildTask(defaults, {}, function () {
-      expect(gutil.log).to.have.been.calledWith('Using msbuild command:', 'msbuild', '/nologo');
+      expect(gutil.log).to.have.been.calledWith(gutil.colors.cyan('Using MSBuild command:'), 'msbuild', '/nologo');
       done();
     });
   });
@@ -77,7 +77,7 @@ describe('msbuild-runner', function () {
     simulateEvent('close', 1);
 
     msbuildRunner.startMsBuildTask(defaults, {}, function () {
-      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('Build failed with code 1!'));
+      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed with code 1!'));
       done();
     });
   });
@@ -86,7 +86,7 @@ describe('msbuild-runner', function () {
     simulateEvent('close', null, 'SIGUSR1');
 
     msbuildRunner.startMsBuildTask(defaults, {}, function () {
-      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('Build killed with signal SIGUSR1!'));
+      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild killed with signal SIGUSR1!'));
       done();
     });
   });
@@ -98,8 +98,8 @@ describe('msbuild-runner', function () {
 
     msbuildRunner.startMsBuildTask(defaults, {}, function (err) {
       expect(err).to.be.an.instanceof(Error);
-      expect(err.message).to.be.equal('Build failed with code 1!');
-      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('Build failed with code 1!'));
+      expect(err.message).to.be.equal('MSBuild failed with code 1!');
+      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed with code 1!'));
       done();
     });
   });
@@ -111,7 +111,7 @@ describe('msbuild-runner', function () {
 
     msbuildRunner.startMsBuildTask(defaults, {}, function () {
       expect(gutil.log).to.have.been.calledWith(error);
-      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('Build failed!'));
+      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed!'));
       done();
     });
   });
@@ -125,7 +125,7 @@ describe('msbuild-runner', function () {
     msbuildRunner.startMsBuildTask(defaults, {}, function (err) {
       expect(err).to.be.equal(error);
       expect(gutil.log).to.have.been.calledWith(error);
-      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('Build failed!'));
+      expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed!'));
       done();
     });
   });


### PR DESCRIPTION
This PR simply makes it clear that gulp-msbuild's log messages are related to MSBuild, rather than the overall build. I find this helpful since my build typically involves running multiple tasks in addition to MSBuild (reporting `Build complete` is a bit misleading when only this specific task has completed).