### PR TITLE
'auto' toolsVersion, templates in properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ properties: { Configuration: 'Debug' }
 
 **Default:** 4.0
 
-**Possible Values:** 1.0, 1.1, 2.0, 3.5, 4.0, 12.0, 14.0
+**Possible Values:** 1.0, 1.1, 2.0, 3.5, 4.0, 12.0, 14.0, ```'auto'```
+
+```'auto'``` attempts to find the latest version >= 12.0, with a fallback to 4.0
 
 #### architecture
 
@@ -124,6 +126,8 @@ msbuild({ architecture: 'x86' })
 ```javascript
 msbuild({ properties: { WarningLevel: 2 } })
 ```
+
+**Hint:** Property values can use ```gulp-util``` templates (e.g. ```"<%= file.path %>"```)
 
 #### verbosity
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var through = require('through2'),
     msbuildRunner = require('./lib/msbuild-runner');
 
 function mergeOptionsWithDefaults(options) {
-  return _.extend(constants.DEFAULTS, options);
+  return _.extend({}, constants.DEFAULTS, options);
 }
 
 module.exports = function(options) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ module.exports = function(options) {
     return msbuildRunner.startMsBuildTask(mergedOptions, file, function(err) {
       if (err) return callback(err);
       self.push(file);
-      self.emit("end");
       return callback();
     });
   });

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -64,12 +64,14 @@ module.exports.construct = function(file, options) {
     options.msbuildPath = msbuildFinder.find(options);
   }
 
-  Object.keys(options.properties).forEach(function(prop) {
+  var newOptions = _.cloneDeep(options);
+
+  Object.keys(newOptions.properties).forEach(function(prop) {
     var context = { file: file };
-    options.properties[prop] = gutil.template(options.properties[prop], context);
+    newOptions.properties[prop] = gutil.template(newOptions.properties[prop], context);
   });
 
-  var args = this.buildArguments(options);
+  var args = this.buildArguments(newOptions);
 
   return {
     executable: path.normalize(options.msbuildPath),

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -64,6 +64,11 @@ module.exports.construct = function(file, options) {
     options.msbuildPath = msbuildFinder.find(options);
   }
 
+  Object.keys(options.properties).forEach(function(prop) {
+    var context = { file: file };
+    options.properties[prop] = gutil.template(options.properties[prop], context);
+  });
+
   var args = this.buildArguments(options);
 
   return {

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -13,14 +13,21 @@ module.exports.find = function (options) {
 
   var version;
 
-  var env_var_dir = process.env['ProgramFiles(x86)'] || process.env['ProgramFiles'];
   var is64Bit = options.architecture === 'x64';
+  var env_var_dir = is64Bit ? process.env['ProgramFiles(x86)'] : process.env['ProgramFiles'];
 
   if (options.toolsVersion === 'auto') {
     // ported from https://github.com/stevewillcock/grunt-msbuild/blob/master/tasks/msbuild.js#L167-L181
     var msbuildDir = path.join(env_var_dir, 'MSBuild');
+    var msbuildDirExists = true;
 
-    if (fs.existsSync(msbuildDir)) {
+    try {
+      fs.statSync(msbuildDir);
+    } catch (e) {
+      msbuildDirExists = false;
+    }
+
+    if (msbuildDirExists) {
        var msbuildVersions = fs.readdirSync(msbuildDir)
            .filter(function(entryName) {
               var binDirExists = true;

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -23,15 +23,24 @@ module.exports.find = function (options) {
     if (fs.existsSync(msbuildDir)) {
        var msbuildVersions = fs.readdirSync(msbuildDir)
            .filter(function(entryName) {
-               return entryName.indexOf('1') === 0;
+              var binDirExists = true;
+              var binDirPath = path.join(msbuildDir, entryName, 'Bin');
+              try {
+                fs.statSync(binDirPath);
+              } catch (e) {
+                binDirExists = false;
+              }
+               return entryName.indexOf('1') === 0 && binDirExists;
            });
 
        if (msbuildVersions.length > 0) {
            // set latest installed msbuild version
            options.toolsVersion = parseFloat(msbuildVersions.pop());
+       } else {
+        options.toolsVersion = 4.0;
        }
     } else {
-      options.toolsVersion = '4.0';
+      options.toolsVersion = 4.0;
     }
   }
   version = constants.MSBUILD_VERSIONS[options.toolsVersion];

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var gutil = require('gulp-util');
 var constants = require('./constants');
+var fs = require('fs');
 var PluginError = gutil.PluginError;
 
 module.exports.find = function (options) {
@@ -10,20 +11,41 @@ module.exports.find = function (options) {
     return 'xbuild';
   }
 
-  var version = constants.MSBUILD_VERSIONS[options.toolsVersion];
+  var version;
+
+  var env_var_dir = process.env['ProgramFiles(x86)'] || process.env['ProgramFiles'];
+  var is64Bit = options.architecture === 'x64';
+
+  if (options.toolsVersion === 'auto') {
+    // ported from https://github.com/stevewillcock/grunt-msbuild/blob/master/tasks/msbuild.js#L167-L181
+    var msbuildDir = path.join(env_var_dir, 'MSBuild');
+
+    if (fs.existsSync(msbuildDir)) {
+       var msbuildVersions = fs.readdirSync(msbuildDir)
+           .filter(function(entryName) {
+               return entryName.indexOf('1') === 0;
+           });
+
+       if (msbuildVersions.length > 0) {
+           // set latest installed msbuild version
+           options.toolsVersion = parseFloat(msbuildVersions.pop());
+       }
+    } else {
+      options.toolsVersion = '4.0';
+    }
+  }
+  version = constants.MSBUILD_VERSIONS[options.toolsVersion];
+
+
   if (!version) {
     throw new PluginError(constants.PLUGIN_NAME, 'No MSBuild Version was supplied!');
   }
-
-  var is64Bit = options.architecture === 'x64';
 
   if (version === '12.0' || version === '14.0') {
     // On 64-bit systems msbuild is always under the x86 directory. If this
     // doesn't exist we are on a 32-bit system. See also:
     // https://blogs.msdn.microsoft.com/visualstudio/2013/07/24/msbuild-is-now-part-of-visual-studio/
-    var env_var_dir = process.env['ProgramFiles(x86)'] || process.env['ProgramFiles'];
     var pathRoot = env_var_dir || path.join('C:', is64Bit ? 'Program Files (x86)' : 'Program Files');
-
     var x64_dir = is64Bit ? 'amd64' : '';
     return path.join(pathRoot, 'MSBuild', version, 'Bin', x64_dir, 'MSBuild.exe');
   }

--- a/test/msbuild-command-builder.js
+++ b/test/msbuild-command-builder.js
@@ -172,6 +172,16 @@ describe('msbuild-command-builder', function () {
       expect(command.executable).to.equal('here');
       expect(command.args).to.contain('test.sln');
     });
+
+    it('should parse templates in properties', function () {
+      var options = defaults;
+      options.properties = { someProp: '<%= file.path %>', anotherProp: 'noTemplate' };
+      options.msbuildPath = 'here';
+      var command = commandBuilder.construct({ path: 'test.sln' }, options);
+
+      expect(command.args).to.contain('/property:someProp=test.sln');
+      expect(command.args).to.contain('/property:anotherProp=noTemplate');
+    });
   });
 
 });

--- a/test/msbuild-finder.js
+++ b/test/msbuild-finder.js
@@ -1,4 +1,4 @@
-/*global describe, it*/
+/*global describe, it, afterEach*/
 'use strict';
 
 var chai          = require('chai'),
@@ -69,7 +69,7 @@ describe('msbuild-finder', function () {
 
   it('should use msbuild 12 on windows with visual studio 2013 project', function () {
     var toolsVersion = 12.0;
-    var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion });
+    var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x86' });
 
     var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
 
@@ -92,7 +92,7 @@ describe('msbuild-finder', function () {
 
   it('should use msbuild 14 on windows with visual studio 2015 project', function () {
     var toolsVersion = 14.0;
-    var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion });
+    var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x86' });
 
     var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
 
@@ -119,6 +119,81 @@ describe('msbuild-finder', function () {
     };
 
     expect(func).to.throw('No MSBuild Version was supplied!');
+  });
+
+  describe('when toolsVersion is \'auto\'', function() {
+    var fs = require('fs');
+    var mock;
+
+    it('should fall back to 4.0 when Visual Studio 2013 and 2015 are not installed', function() {
+      var windir = 'WINDIR';
+      var toolsVersion = 'auto';
+
+      var expectMSBuildVersion = constants.MSBUILD_VERSIONS[4.0];
+      var expectedResult = path.join(windir, 'Microsoft.Net', 'Framework', expectMSBuildVersion, 'MSBuild.exe');
+
+      mock = this.sinon.mock(fs);
+      mock.expects('statSync').throws();
+
+      var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, windir: windir });
+
+      expect(result).to.be.equal(expectedResult);
+    });
+
+    it('should fall back to 4.0 when MSBuild dir exists in Program Files, but no versions installed', function () {
+      var windir = 'WINDIR';
+      var toolsVersion = 'auto';
+      var expectMSBuildVersion = constants.MSBUILD_VERSIONS[4.0];
+      var pathRoot = process.env['ProgramFiles'] || path.join('C:', 'Program Files');
+      var msbuildDir = path.join(pathRoot, 'MSBuild');
+      var expectedResult = path.join(windir, 'Microsoft.Net', 'Framework', expectMSBuildVersion, 'MSBuild.exe');
+
+      mock = this.sinon.mock(fs);
+      mock.expects('readdirSync').withArgs(msbuildDir).returns(['padding', 'dir']);
+
+      var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, windir: windir });
+
+      expect(result).to.be.equal(expectedResult);
+    });
+
+    it('should use msbuild 14 on windows with visual studio 2015 project', function () {
+      var toolsVersion = 'auto';
+      var expectMSBuildVersion = constants.MSBUILD_VERSIONS[14.0];
+      var pathRoot = process.env['ProgramFiles'] || path.join('C:', 'Program Files');
+      var msbuildDir = path.join(pathRoot, 'MSBuild');
+      var expectedResult = path.join(pathRoot, 'MSBuild', expectMSBuildVersion, 'Bin', 'MSBuild.exe');
+
+      mock = this.sinon.mock(fs);
+      mock.expects('readdirSync').withArgs(msbuildDir).returns(['padding', 'dir', '14.0']);
+      mock.expects('statSync').withArgs(msbuildDir).returns({});
+      mock.expects('statSync').withArgs(path.join(msbuildDir, '14.0', 'Bin')).returns({});
+
+      var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x86' });
+
+      expect(result).to.be.equal(expectedResult);
+    });
+
+    it('should use msbuild 12 on windows with visual studio 2013 project and an incomplete visual studio 2015 install', function () {
+      var toolsVersion = 'auto';
+      var expectMSBuildVersion = constants.MSBUILD_VERSIONS[12.0];
+      var pathRoot = process.env['ProgramFiles'] || path.join('C:', 'Program Files');
+      var msbuildDir = path.join(pathRoot, 'MSBuild');
+      var expectedResult = path.join(pathRoot, 'MSBuild', expectMSBuildVersion, 'Bin', 'MSBuild.exe');
+
+      mock = this.sinon.mock(fs);
+      mock.expects('readdirSync').withArgs(msbuildDir).returns(['padding', 'dir', '12.0', '14.0']);
+      mock.expects('statSync').withArgs(msbuildDir).returns({});
+      mock.expects('statSync').withArgs(path.join(msbuildDir, '12.0', 'Bin')).returns({});
+      mock.expects('statSync').withArgs(path.join(msbuildDir, '14.0', 'Bin')).throws();
+
+      var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x86' });
+
+      expect(result).to.be.equal(expectedResult);
+    });
+
+    afterEach(function() {
+      mock.restore();
+    });
   });
 
 });

--- a/test/msbuild-finder.js
+++ b/test/msbuild-finder.js
@@ -1,4 +1,4 @@
-/*global describe, it, afterEach*/
+/*global describe, it, afterEach, before*/
 'use strict';
 
 var chai          = require('chai'),
@@ -125,6 +125,10 @@ describe('msbuild-finder', function () {
     var fs = require('fs');
     var mock;
 
+    before(function() {
+      process.env['ProgramFiles'] = path.join('C:', 'Program Files');
+    });
+
     it('should fall back to 4.0 when Visual Studio 2013 and 2015 are not installed', function() {
       var windir = 'WINDIR';
       var toolsVersion = 'auto';
@@ -149,6 +153,7 @@ describe('msbuild-finder', function () {
       var expectedResult = path.join(windir, 'Microsoft.Net', 'Framework', expectMSBuildVersion, 'MSBuild.exe');
 
       mock = this.sinon.mock(fs);
+      mock.expects('statSync').returns({});
       mock.expects('readdirSync').withArgs(msbuildDir).returns(['padding', 'dir']);
 
       var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, windir: windir });


### PR DESCRIPTION
Changes:

  - Added 'auto' option to ```toolsVersion```. When set to 'auto', will look for the latest version >= 12.0, with a fallback to 4.0
  - Added capability to include gulp-util templates in ```properties```