### PR TITLE
Support for custom arguments

### DIFF
--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -51,6 +51,10 @@ module.exports.buildArguments = function(options) {
     args.push('/property:' + property + '=' + options.properties[property]);
   }
 
+  if(options.customArgs) {
+	args = args.concat(options.customArgs);
+  }
+
   return args;
 };
 

--- a/test/msbuild-command-builder.js
+++ b/test/msbuild-command-builder.js
@@ -172,6 +172,14 @@ describe('msbuild-command-builder', function () {
       expect(command.executable).to.equal('here');
       expect(command.args).to.contain('test.sln');
     });
+
+    it('should include arguments passed by customArgs', function () {
+      var options = defaults;
+      options.customArgs = ['/custom1', '/custom2'];
+      var result = commandBuilder.buildArguments(options);
+
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Configuration=Release', '/custom1', '/custom2']);
+    });
   });
 
 });


### PR DESCRIPTION
Msbuild, especially with Roslyn, has a lot of new or experimental features that are infeasible to keep up with, so I'd like to propose adding the ability to add new arguments to the command as they become available to msbuild without having to wait for `gulp-msbuild` to support them. The functionality of `customArgs` is the same as in `grunt-msbuild`.