### PR TITLE
Add customArgs to DEFAULTS

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -34,7 +34,8 @@ module.exports = {
     fileLoggerParameters: undefined,
     consoleLoggerParameters: undefined,
     loggerParameters: undefined,
-    nodeReuse: true
+    nodeReuse: true,
+    customArgs: []
   }
 };
 


### PR DESCRIPTION
This fixes the issue introduced in 997da5d520d7d8f080fa36a1f7762b39a13ab2d3, where `customArgs` was rejected as an invalid option