### PR TITLE
Add support for solution platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ gulp.task("default", function() {
 properties: { Configuration: 'Debug' }
 ```
 
+#### solution platform
+
+> Specify the Solution Platform (e.g. x86, x64, AnyCPU)
+
+**Hint:** You can also specify the Solution Platform using the *properties* option
+```js
+properties: { Platform: 'AnyCPU' }
+```
+
 #### toolsVersion
 
 > Specify the .NET Tools-Version

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ gulp.task("default", function() {
 properties: { Configuration: 'Debug' }
 ```
 
-#### solution platform
+#### solutionPlatform
 
 > Specify the Solution Platform (e.g. x86, x64, AnyCPU)
 

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -53,11 +53,17 @@ module.exports.buildArguments = function(options) {
     }, options.properties);
   }
 
+  if (options.solutionPlatform) {
+    options.properties = _.extend({
+      'Platform': options.solutionPlatform
+    }, options.properties);
+  }
+
   for (var property in options.properties) {
     args.push('/property:' + property + '=' + options.properties[property]);
   }
 
-  if(options.customArgs) {
+  if (options.customArgs) {
     args = args.concat(options.customArgs);
   }
 

--- a/test/msbuild-command-builder.js
+++ b/test/msbuild-command-builder.js
@@ -125,6 +125,23 @@ describe('msbuild-command-builder', function () {
       expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Configuration=Debug']);
     });
 
+    it('should add SolutionPlatform Property when SolutionPlatform-Option is specified', function () {
+      var options = defaults;
+      options.solutionPlatform = 'AnyCPU';
+      var result = commandBuilder.buildArguments(options);
+
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Platform=AnyCPU', '/property:Configuration=Release']);
+    });
+
+    it('should use SolutionPlatform Property in the custom properties list when specified', function () {
+      var options = defaults;
+      options.solutionPlatform = 'AnyCPU';
+      options.properties = { Platform: 'x86' };
+      var result = commandBuilder.buildArguments(options);
+
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Platform=x86', '/property:Configuration=Release']);
+    });
+
     it('should use fileLoggerParameters when specified', function () {
       var options = defaults;
       options.fileLoggerParameters = 'LogFile=Build.log';
@@ -178,7 +195,7 @@ describe('msbuild-command-builder', function () {
     });
 
     it('should use msbuildpath if specified', function () {
-      this.sinon.stub(msbuildFinder, 'find')  ;
+      this.sinon.stub(msbuildFinder, 'find');
 
       var options = defaults;
       options.msbuildPath = 'here';


### PR DESCRIPTION
Hi all, in my project we are building for multiple target platforms (x64, x86 and AnyCPU). It took us some time to figure out how to specify the correct platform when using gulp-msbuild. So it would be good if the platform-property is easier accessible.