### PR TITLE
Emit end event

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ msbuild({ loggerParameters: 'XMLLogger,./MyLogger.dll;OutputAsHTML' })
 msbuild({ customArgs: ['/noautoresponse'] })
 ```
 
+#### emitEndEvent
+
+> Specify if a gulp end-event should be emitted.
+
+**Default:** false = No end event is emitted.
+
+**Possible Values:** true, false
+
+
 ### MSBuild Command-Line Reference
 
 For a more detailed description of each MSBuild Option see the [MSBuild Command-Line Reference](http://msdn.microsoft.com/en-us/library/ms164311.aspx)

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = function(options) {
     return msbuildRunner.startMsBuildTask(mergedOptions, file, function(err) {
       if (err) return callback(err);
       self.push(file);
-      self.emit("end");
+      if (mergedOptions.emitEndEvent) self.emit("end");
       return callback();
     });
   });

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = function(options) {
     return msbuildRunner.startMsBuildTask(mergedOptions, file, function(err) {
       if (err) return callback(err);
       self.push(file);
+      self.emit("end");
       return callback();
     });
   });

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -36,7 +36,8 @@ module.exports = {
     consoleLoggerParameters: undefined,
     loggerParameters: undefined,
     nodeReuse: true,
-    customArgs: []
+    customArgs: [],
+    emitEndEvent: false
   }
 };
 


### PR DESCRIPTION
Added end-event for gulp again, cause it doesn't work without on my machine (Windows 10, Node 7.x)