### PR TITLE
Add emission of published files

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ module.exports = function(options) {
 
     return msbuildRunner.startMsBuildTask(mergedOptions, file, self, function(err) {
       if (err) return callback(err);
-      self.push(file);
       if (mergedOptions.emitEndEvent) self.emit("end");
       return callback();
     });

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function(options) {
       return callback();
     }
 
-    return msbuildRunner.startMsBuildTask(mergedOptions, file, function(err) {
+    return msbuildRunner.startMsBuildTask(mergedOptions, file, self, function(err) {
       if (err) return callback(err);
       self.push(file);
       if (mergedOptions.emitEndEvent) self.emit("end");

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,6 +2,7 @@
 
 var os = require('os');
 var uuid = require('uuid');
+var join = require('path').join;
 
 module.exports = {
   PLUGIN_NAME: 'gulp-msbuild',
@@ -45,7 +46,7 @@ module.exports = {
     webPublishMethod: 'FileSystem',
     deleteExistingFiles: 'true',
     findDependencies: 'true',
-    publishDirectory: uuid.v4()
+    publishDirectory: join(os.tmpdir(), uuid.v4())
   }
 };
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var os = require('os');
+var uuid = require('uuid');
 
 module.exports = {
   PLUGIN_NAME: 'gulp-msbuild',
@@ -43,7 +44,8 @@ module.exports = {
     deployDefaultTarget: 'WebPublish',
     webPublishMethod: 'FileSystem',
     deleteExistingFiles: 'true',
-    findDependencies: 'true'
+    findDependencies: 'true',
+    publishDirectory: uuid.v4()
   }
 };
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -38,7 +38,12 @@ module.exports = {
     nodeReuse: true,
     customArgs: [],
     emitEndEvent: false,
-    solutionPlatform: null
+    solutionPlatform: null,
+    emitPublishedFiles: false,
+    deployDefaultTarget: 'WebPublish',
+    webPublishMethod: 'FileSystem',
+    deleteExistingFiles: 'true',
+    findDependencies: 'true'
   }
 };
 

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -4,7 +4,6 @@ var _ = require('lodash');
 var path = require('path');
 var constants = require('./constants');
 var gutil = require('gulp-util');
-var uuid = require('uuid');
 var PluginError = gutil.PluginError;
 
 module.exports.buildArguments = function(options) {
@@ -67,7 +66,7 @@ module.exports.buildArguments = function(options) {
       'WebPublishMethod': options.webPublishMethod,
       'DeleteExistingFiles': options.deleteExistingFiles,
       '_FindDependencies': options.findDependencies,
-      'PublishUrl': options.publishUrl || uuid.v4()
+      'PublishUrl': options.publishDirectory
     }, options.properties);
   }
 

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var path = require('path');
 var constants = require('./constants');
 var gutil = require('gulp-util');
+var uuid = require('uuid');
 var PluginError = gutil.PluginError;
 
 module.exports.buildArguments = function(options) {
@@ -56,6 +57,17 @@ module.exports.buildArguments = function(options) {
   if (options.solutionPlatform) {
     options.properties = _.extend({
       'Platform': options.solutionPlatform
+    }, options.properties);
+  }
+
+  if (options.emitPublishedFiles) {
+    options.properties = _.extend({
+      'DeployOnBuild': 'true',
+      'DeployDefaultTarget': options.deployDefaultTarget,
+      'WebPublishMethod': options.webPublishMethod,
+      'DeleteExistingFiles': options.deleteExistingFiles,
+      '_FindDependencies': options.findDependencies,
+      'PublishUrl': options.publishUrl || uuid.v4()
     }, options.properties);
   }
 

--- a/lib/msbuild-runner.js
+++ b/lib/msbuild-runner.js
@@ -41,22 +41,22 @@ module.exports.startMsBuildTask = function (options, file, stream, callback) {
       gutil.log(gutil.colors.cyan('MSBuild complete!'));
 
       if (options.emitPublishedFiles) {
-        var publishUrl = options.properties.PublishUrl;
-        glob('**/*', { cwd: publishUrl }, function (err, files) {
+        var publishDirectory = options.publishDirectory;
+        glob('**/*', { cwd: publishDirectory, nodir: true, absolute: true }, function (err, files) {
           if (err) {
-            var msg = 'Error globbing published files at ' + publishUrl;
+            var msg = 'Error globbing published files at ' + publishDirectory;
             gutil.log(gutil.colors.red(msg));
             return callback(err);
           }
 
           for (var i = 0; i < files.length; i++) {
             var filePath = files[i];
-            var destinationPath = join(publishUrl, filePath);
+            var destinationPath = join(publishDirectory, filePath);
 
             if (fs.statSync(filePath).isFile()) {
               stream.push(new gutil.File({
-                cwd: publishUrl,
-                base: publishUrl,
+                cwd: publishDirectory,
+                base: publishDirectory,
                 path: destinationPath,
                 contents: new Buffer(fs.readFileSync(filePath))
               }));

--- a/lib/msbuild-runner.js
+++ b/lib/msbuild-runner.js
@@ -51,13 +51,12 @@ module.exports.startMsBuildTask = function (options, file, stream, callback) {
 
           for (var i = 0; i < files.length; i++) {
             var filePath = files[i];
-            var destinationPath = join(publishDirectory, filePath);
 
             if (fs.statSync(filePath).isFile()) {
               stream.push(new gutil.File({
                 cwd: publishDirectory,
                 base: publishDirectory,
-                path: destinationPath,
+                path: filePath,
                 contents: new Buffer(fs.readFileSync(filePath))
               }));
             }

--- a/lib/msbuild-runner.js
+++ b/lib/msbuild-runner.js
@@ -61,6 +61,7 @@ module.exports.startMsBuildTask = function (options, file, stream, callback) {
               }));
             }
           }
+          return callback();
         });
       }
     } else {
@@ -80,7 +81,5 @@ module.exports.startMsBuildTask = function (options, file, stream, callback) {
         return callback(new Error(msg));
       }
     }
-
-    return callback();
   });
 };

--- a/lib/msbuild-runner.js
+++ b/lib/msbuild-runner.js
@@ -2,9 +2,12 @@
 
 var commandBuilder = require('./msbuild-command-builder');
 var gutil = require('gulp-util');
+var glob = require('glob');
+var join = require('path').join;
+var fs = require('fs');
 var childProcess = require('child_process');
 
-module.exports.startMsBuildTask = function (options, file, callback) {
+module.exports.startMsBuildTask = function (options, file, stream, callback) {
   var command = commandBuilder.construct(file, options);
 
   if (options.logCommand) {
@@ -36,6 +39,31 @@ module.exports.startMsBuildTask = function (options, file, callback) {
   cp.on('close', function (code, signal) {
     if (code === 0) {
       gutil.log(gutil.colors.cyan('MSBuild complete!'));
+
+      if (options.emitPublishedFiles) {
+        var publishUrl = options.properties.PublishUrl;
+        glob('**/*', { cwd: publishUrl }, function (err, files) {
+          if (err) {
+            var msg = 'Error globbing published files at ' + publishUrl;
+            gutil.log(gutil.colors.red(msg));
+            return callback(new Error(msg));
+          }
+
+          for (var i = 0; i < files.length; i++) {
+            var fileName = files[i];
+            var filePath = join(publishUrl, fileName);
+
+            if (fs.statSync(filePath).isFile()) {
+              stream.push(new gutil.File({
+                cwd: publishUrl,
+                base: publishUrl,
+                path: filePath,
+                contents: new Buffer(fs.readFileSynce(filePath))
+              }));
+            }
+          }
+        });
+      }
     } else {
       var msg;
 

--- a/lib/msbuild-runner.js
+++ b/lib/msbuild-runner.js
@@ -46,19 +46,19 @@ module.exports.startMsBuildTask = function (options, file, stream, callback) {
           if (err) {
             var msg = 'Error globbing published files at ' + publishUrl;
             gutil.log(gutil.colors.red(msg));
-            return callback(new Error(msg));
+            return callback(err);
           }
 
           for (var i = 0; i < files.length; i++) {
-            var fileName = files[i];
-            var filePath = join(publishUrl, fileName);
+            var filePath = files[i];
+            var destinationPath = join(publishUrl, filePath);
 
             if (fs.statSync(filePath).isFile()) {
               stream.push(new gutil.File({
                 cwd: publishUrl,
                 base: publishUrl,
-                path: filePath,
-                contents: new Buffer(fs.readFileSynce(filePath))
+                path: destinationPath,
+                contents: new Buffer(fs.readFileSync(filePath))
               }));
             }
           }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mocha": "*",
     "mocha-lcov-reporter": "*",
     "mocha-sinon": "^1.1.6",
+    "proxyquire": "^1.8.0",
     "sinon": ">=1.4.0 <2",
     "sinon-chai": "^2.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
+    "didyoumean": "~1.2.1",
+    "glob": "^7.1.1",
     "gulp-util": ">=3.0.0",
     "lodash": "^4.0.0",
-    "didyoumean": "~1.2.1",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "chai": "^3.4.0",

--- a/test/msbuild-command-builder.js
+++ b/test/msbuild-command-builder.js
@@ -173,6 +173,15 @@ describe('msbuild-command-builder', function () {
 
       expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/nodeReuse:False', '/property:Configuration=Release']);
     });
+
+    it('should add publish properties when emitPublishedFiles is true', function () {
+      var options = defaults;
+      options.emitPublishedFiles = true;
+      options.publishDirectory = 'dummy';
+      var result = commandBuilder.buildArguments(options);
+
+      expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:DeployOnBuild=true', '/property:DeployDefaultTarget=WebPublish', '/property:WebPublishMethod=FileSystem', '/property:DeleteExistingFiles=true', '/property:_FindDependencies=true', '/property:PublishUrl=dummy', '/property:Configuration=Release']);
+    });
   });
 
 
@@ -232,5 +241,4 @@ describe('msbuild-command-builder', function () {
       expect(command.args).to.contain('/property:anotherProp=noTemplate');
     });
   });
-
 });

--- a/test/msbuild-runner.js
+++ b/test/msbuild-runner.js
@@ -61,10 +61,10 @@ describe('msbuild-runner', function () {
 
     msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(gutil.colors.cyan('MSBuild complete!'));
-      done();
     });
 
     expect(childProcess.spawn).to.have.been.calledWith('msbuild', ['/nologo']);
+    done();
   });
 
   it('should log the command when the logCommand option is set', function(done) {
@@ -74,8 +74,8 @@ describe('msbuild-runner', function () {
 
     msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(gutil.colors.cyan('Using MSBuild command:'), 'msbuild', '/nologo');
-      done();
     });
+    done();
   });
 
   it('should log an error message when the msbuild command exits with a non-zero code', function (done) {
@@ -83,8 +83,8 @@ describe('msbuild-runner', function () {
 
     msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed with code 1!'));
-      done();
     });
+    done();
   });
 
   it('should log an error message when the msbuild command is killed by a signal', function (done) {
@@ -92,8 +92,8 @@ describe('msbuild-runner', function () {
 
     msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild killed with signal SIGUSR1!'));
-      done();
     });
+    done();
   });
 
   it('should log an error message and return an Error in the callback when the msbuild command failed', function (done) {
@@ -105,8 +105,8 @@ describe('msbuild-runner', function () {
       expect(err).to.be.an.instanceof(Error);
       expect(err.message).to.be.equal('MSBuild failed with code 1!');
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed with code 1!'));
-      done();
     });
+    done();
   });
 
   it('should log an error message when the spawned process experienced an error', function (done) {
@@ -117,8 +117,8 @@ describe('msbuild-runner', function () {
     msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(error);
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed!'));
-      done();
     });
+    done();
   });
 
   it('should log an error message and return an Error in the callback when the spawned process experienced an error', function (done) {
@@ -154,33 +154,6 @@ describe('msbuild-runner', function () {
     });
   });
 
-  it('should call join with the publishUrl and the file path for each file', function(done) {
-    defaults.emitPublishedFiles = true;
-    defaults.publishDirectory = 'foobar';
-
-    var fileArray = [
-      'foo.js',
-      'bar.js'
-    ];
-
-    var mockGlob = this.sinon.stub().callsArgWith(2, null, fileArray);
-    var msbuildRunner = proxyquire('../lib/msbuild-runner', { 'glob': mockGlob });
-
-    var stubStatsObj = {
-      isFile: function() { return false; }
-    };
-    this.sinon.stub(fs, 'statSync').returns(stubStatsObj);
-
-    simulateEvent('close', 0);
-
-    msbuildRunner.startMsBuildTask(defaults, {}, null, function(err) {
-      expect(path.join).to.have.been.calledWith('foobar', fileArray[0]);
-      expect(path.join).to.have.been.calledWith('foobar', fileArray[1]);
-      done();
-    });
-  });
-
-
   it('should should push gutil files for each file with the correct attributes', function(done) {
     defaults.emitPublishedFiles = true;
 
@@ -193,8 +166,8 @@ describe('msbuild-runner', function () {
     ];
 
     var pathArray = [
-      'foobar/foo.js',
-      'foobar/bar.js'
+      'foo.js',
+      'bar.js'
     ];
 
     var contentArray = [

--- a/test/msbuild-runner.js
+++ b/test/msbuild-runner.js
@@ -54,7 +54,7 @@ describe('msbuild-runner', function () {
 
     simulateEvent('close', 0);
 
-    msbuildRunner.startMsBuildTask(defaults, {}, function () {
+    msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(gutil.colors.cyan('MSBuild complete!'));
       done();
     });
@@ -67,7 +67,7 @@ describe('msbuild-runner', function () {
 
     simulateEvent('close', 0);
 
-    msbuildRunner.startMsBuildTask(defaults, {}, function () {
+    msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(gutil.colors.cyan('Using MSBuild command:'), 'msbuild', '/nologo');
       done();
     });
@@ -76,7 +76,7 @@ describe('msbuild-runner', function () {
   it('should log an error message when the msbuild command exits with a non-zero code', function (done) {
     simulateEvent('close', 1);
 
-    msbuildRunner.startMsBuildTask(defaults, {}, function () {
+    msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed with code 1!'));
       done();
     });
@@ -85,7 +85,7 @@ describe('msbuild-runner', function () {
   it('should log an error message when the msbuild command is killed by a signal', function (done) {
     simulateEvent('close', null, 'SIGUSR1');
 
-    msbuildRunner.startMsBuildTask(defaults, {}, function () {
+    msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild killed with signal SIGUSR1!'));
       done();
     });
@@ -96,7 +96,7 @@ describe('msbuild-runner', function () {
 
     simulateEvent('close', 1);
 
-    msbuildRunner.startMsBuildTask(defaults, {}, function (err) {
+    msbuildRunner.startMsBuildTask(defaults, {}, null, function (err) {
       expect(err).to.be.an.instanceof(Error);
       expect(err.message).to.be.equal('MSBuild failed with code 1!');
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed with code 1!'));
@@ -109,7 +109,7 @@ describe('msbuild-runner', function () {
 
     simulateEvent('error', error);
 
-    msbuildRunner.startMsBuildTask(defaults, {}, function () {
+    msbuildRunner.startMsBuildTask(defaults, {}, null, function () {
       expect(gutil.log).to.have.been.calledWith(error);
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed!'));
       done();
@@ -122,7 +122,7 @@ describe('msbuild-runner', function () {
 
     simulateEvent('error', error);
 
-    msbuildRunner.startMsBuildTask(defaults, {}, function (err) {
+    msbuildRunner.startMsBuildTask(defaults, {}, null, function (err) {
       expect(err).to.be.equal(error);
       expect(gutil.log).to.have.been.calledWith(error);
       expect(gutil.log).to.have.been.calledWith(gutil.colors.red('MSBuild failed!'));


### PR DESCRIPTION
This adds an option which allows you to emit published to the stream. This is incredibly useful because it neatly encapsulates publishing your code to a temporary directory and then returning a stream of the published files. This makes it easy to pipe the stream into other gulp plugins to perform further work on the published files.

As discussed in issue #46, this adds the following functionality:
* an `emitPublishedFiles` option which causes the published files to be emitted by the plugin. Setting this to true causes the required msbuild options to be added to the msbuild command that enables a filesystem publish to a the provided directory
* an accompanying option, `publishDirectory` which controls where the files are published to on the filesystem. If this option is not specified, the publishDirectory defaults to a directory inside the system temp folder, with a folder name based on a uuid v4

I have added some unit tests of this functionality, but feel free to suggest more.