### PR TITLE
Add Linux MSBuild detection

### DIFF
--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -5,7 +5,7 @@ var gutil = require('gulp-util');
 var constants = require('./constants');
 var fs = require('fs');
 var PluginError = gutil.PluginError;
-var spawnSync = require ('child_process').spawnSync;
+var child = require ('child_process');
 
 var detectMsBuild15Dir = function (pathRoot) {
   var vs2017Path = path.join(pathRoot, 'Microsoft Visual Studio', '2017');
@@ -23,7 +23,7 @@ var detectMsBuild15Dir = function (pathRoot) {
 // Use MSBuild over XBuild where possible
 var detectLinuxMsBuildExecutable = function () {
   try {
-    var output = spawnSync('which', ['msbuild'], {encoding: 'utf8'});
+    var output = child.spawnSync('which', ['msbuild'], {encoding: 'utf8'});
     if (output.stderr && output.stderr !== 0) {
       return 'xbuild';
     }

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -5,6 +5,7 @@ var gutil = require('gulp-util');
 var constants = require('./constants');
 var fs = require('fs');
 var PluginError = gutil.PluginError;
+var spawnSync = require ('child_process').spawnSync;
 
 var detectMsBuild15Dir = function (pathRoot) {
   var vs2017Path = path.join(pathRoot, 'Microsoft Visual Studio', '2017');
@@ -21,16 +22,13 @@ var detectMsBuild15Dir = function (pathRoot) {
 
 // Use MSBuild over XBuild where possible
 var detectLinuxMsBuildExecutable = function () {
-  var msbuildExecutable = 'msbuild';
-  var possibleFolders = ['/usr/bin/'];
-
-  for (var index = 0; index < possibleFolders.length; index++) {
-    try {
-      var filePath = path.join(possibleFolders[index], msbuildExecutable);
-      fs.statSync(filePath);
-      return filePath;
-    } catch (e) {}
-  }
+  try {
+    var output = spawnSync('which', ['msbuild'], {encoding: 'utf8'});
+    if (output.stderr && output.stderr !== 0) {
+      return 'xbuild';
+    }
+    return 'msbuild';
+  } catch (e) {}
 }
 
 var autoDetectVersion = function (pathRoot) {

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -19,6 +19,20 @@ var detectMsBuild15Dir = function(pathRoot) {
   }
 }
 
+// Use MSBuild over XBuild where possible
+var detectLinuxMsBuildExecutable = function() {
+  var msbuildExecutable = 'msbuild';
+  var possibleFolders = ['/usr/bin/'];
+
+  for(var index = 0; index < possibleFolders.length; index++) {
+    try {
+      var filePath = path.join(possibleFolders[index], msbuildExecutable);
+      fs.statSync(filePath);
+      return filePath;
+    } catch (e) { }
+  }
+}
+
 var autoDetectVersion = function(pathRoot) {
   // Try to detect MSBuild 15.0.
   var msbuild15Dir = detectMsBuild15Dir(pathRoot);
@@ -62,6 +76,10 @@ var autoDetectVersion = function(pathRoot) {
 
 module.exports.find = function (options) {
   if (!options.platform.match(/^win/)) {
+    var msbuildPath = detectLinuxMsBuildExecutable();
+    if (msbuildPath) {
+      return msbuildPath;
+    }
     return 'xbuild';
   }
 

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -6,34 +6,34 @@ var constants = require('./constants');
 var fs = require('fs');
 var PluginError = gutil.PluginError;
 
-var detectMsBuild15Dir = function(pathRoot) {
+var detectMsBuild15Dir = function (pathRoot) {
   var vs2017Path = path.join(pathRoot, 'Microsoft Visual Studio', '2017');
   var possibleFolders = ['BuildTools', 'Enterprise', 'Professional', 'Community'];
 
-  for(var index = 0; index < possibleFolders.length; index++) {
+  for (var index = 0; index < possibleFolders.length; index++) {
     try {
       var folderPath = path.join(vs2017Path, possibleFolders[index]);
       fs.statSync(folderPath);
       return folderPath;
-    } catch (e) { }
+    } catch (e) {}
   }
 }
 
 // Use MSBuild over XBuild where possible
-var detectLinuxMsBuildExecutable = function() {
+var detectLinuxMsBuildExecutable = function () {
   var msbuildExecutable = 'msbuild';
   var possibleFolders = ['/usr/bin/'];
 
-  for(var index = 0; index < possibleFolders.length; index++) {
+  for (var index = 0; index < possibleFolders.length; index++) {
     try {
       var filePath = path.join(possibleFolders[index], msbuildExecutable);
       fs.statSync(filePath);
       return filePath;
-    } catch (e) { }
+    } catch (e) {}
   }
 }
 
-var autoDetectVersion = function(pathRoot) {
+var autoDetectVersion = function (pathRoot) {
   // Try to detect MSBuild 15.0.
   var msbuild15Dir = detectMsBuild15Dir(pathRoot);
   if (msbuild15Dir) {
@@ -53,7 +53,7 @@ var autoDetectVersion = function(pathRoot) {
 
   if (msbuildDirExists) {
     var msbuildVersions = fs.readdirSync(msbuildDir)
-      .filter(function(entryName) {
+      .filter(function (entryName) {
         var binDirExists = true;
         var binDirPath = path.join(msbuildDir, entryName, 'Bin');
         try {
@@ -75,11 +75,13 @@ var autoDetectVersion = function(pathRoot) {
 };
 
 module.exports.find = function (options) {
-  if (!options.platform.match(/^win/)) {
+  if (options.platform.match(/linux/)) {
     var msbuildPath = detectLinuxMsBuildExecutable();
     if (msbuildPath) {
       return msbuildPath;
     }
+    return 'xbuild';
+  } else if (!options.platform.match(/^win/)) {
     return 'xbuild';
   }
 

--- a/test/msbuild-finder.js
+++ b/test/msbuild-finder.js
@@ -16,10 +16,10 @@ describe('msbuild-finder', function () {
   var fs = require('fs');
   var mock;
 
-  it('should use msbuild on linux', function () {
+  it('should use msbuild OR xbuild on linux', function () {
     var result = msbuildFinder.find({ platform: 'linux' });
 
-    expect(result).to.include('msbuild');
+    expect(result).to.be.oneOf(['msbuild','xbuild']);
   });
 
   it('should use xbuild on darwin', function () {

--- a/test/msbuild-finder.js
+++ b/test/msbuild-finder.js
@@ -16,10 +16,29 @@ describe('msbuild-finder', function () {
   var fs = require('fs');
   var mock;
 
-  it('should use msbuild OR xbuild on linux', function () {
-    var result = msbuildFinder.find({ platform: 'linux' });
+  describe('linux platorm', function() {
+    var child = require ('child_process');
 
-    expect(result).to.be.oneOf(['msbuild','xbuild']);
+    it('should use msbuild if possible', function () {
+
+      var mock = this.sinon.mock(child);
+      mock.expects('spawnSync').withArgs('which', ['msbuild'], {encoding: 'utf8'}).returns({});
+
+      var result = msbuildFinder.find({ platform: 'linux' });
+
+      expect(result).to.be.equal('msbuild');
+    });
+
+    it('should fallback to xbuild when msbuild is not present', function () {
+
+      var mock = this.sinon.mock(child);
+      mock.expects('spawnSync').withArgs('which', ['msbuild'], {encoding: 'utf8'}).returns({
+        stderr: 1
+      });
+
+      var result = msbuildFinder.find({ platform: 'linux' });
+      expect(result).to.be.equal('xbuild');
+    });
   });
 
   it('should use xbuild on darwin', function () {

--- a/test/msbuild-finder.js
+++ b/test/msbuild-finder.js
@@ -16,10 +16,10 @@ describe('msbuild-finder', function () {
   var fs = require('fs');
   var mock;
 
-  it('should use xbuild on linux', function () {
+  it('should use msbuild on linux', function () {
     var result = msbuildFinder.find({ platform: 'linux' });
 
-    expect(result).to.be.equal('xbuild');
+    expect(result).to.include('msbuild');
   });
 
   it('should use xbuild on darwin', function () {


### PR DESCRIPTION
This change adds support for MSBuild in Linux as opposed to defaulting to xbuild (which is soon to be deprecated)