### PR TITLE
Revise the VS 2017 version 15 tools to use vswhere Issue #55

### DIFF
--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -32,9 +32,14 @@ var msBuildFromWhere = function(pathRoot) {
 	}	
 	var installKeyword = 'installationPath';
 	if (cmdOutput.length > 0) {
-		var results = cmdOutput.split(/\r?\n/);
-		var match = results.filter(z => z.startsWith(installKeyword)).shift();
-		return match.replace(`${installKeyword}: `, '');
+		var results = cmdOutput.split(/\r?\n/);		
+		for (var cmdLineIndex = 0; cmdLineIndex < results.length; cmdLineIndex++) {
+			var cmdLine = results[cmdLineIndex];
+			if (cmdLine.startsWith(installKeyword)) {
+				var match = cmdLine.replace(installKeyword + ': ', '');
+				return match;
+			}
+		}		
 	}
 	return ''; 
 }

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -8,47 +8,45 @@ var PluginError = gutil.PluginError;
 var child = require ('child_process');
 
 
-var msBuildFromWhere = function(pathRoot) {	
-	var vsWherePath = path.join(pathRoot, 'Microsoft Visual Studio','Installer', 'vswhere.exe');
-	var whereProcess = child.spawnSync(vsWherePath,
-	{
-		cwd: process.cwd(),
-		env: process.env,
-		stdio: 'pipe',
-		encoding: 'utf-8'
-	});
-	
-	var cmdOutput = '';
-	if (whereProcess.output === null) {
-		return '';
-	}	
-	if (whereProcess.output.length > 0){
-		for (var index = 0; index < whereProcess.output.length; index++) {
-			cmdOutput = whereProcess.output[index] || '';
-			if (cmdOutput.length > 0) {
-				break;
-			}
-		}		
-	}	
-	var installKeyword = 'installationPath';
-	if (cmdOutput.length > 0) {
-		var results = cmdOutput.split(/\r?\n/);		
-		for (var cmdLineIndex = 0; cmdLineIndex < results.length; cmdLineIndex++) {
-			var cmdLine = results[cmdLineIndex];
-			if (cmdLine.startsWith(installKeyword)) {
-				var match = cmdLine.replace(installKeyword + ': ', '');
-				return match;
-			}
-		}		
-	}
-	return ''; 
+var msBuildFromWhere = function(pathRoot) {  
+  var vsWherePath = path.join(pathRoot, 'Microsoft Visual Studio','Installer', 'vswhere.exe');
+  var whereProcess = child.spawnSync(vsWherePath,
+  {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'pipe',
+    encoding: 'utf-8'
+  });
+  
+  var cmdOutput = '';
+  if (whereProcess.output === null) {
+    return '';
+  }  
+  if (whereProcess.output.length > 0){
+    for (var index = 0; index < whereProcess.output.length; index++) {
+      cmdOutput = whereProcess.output[index] || '';
+      if (cmdOutput.length > 0) {
+        break;
+      }
+    }    
+  }  
+  var installKeyword = 'installationPath';
+  if (cmdOutput.length > 0) {
+    var results = cmdOutput.split(/\r?\n/);    
+    for (var cmdLineIndex = 0; cmdLineIndex < results.length; cmdLineIndex++) {
+      var cmdLine = results[cmdLineIndex];
+      if (cmdLine.startsWith(installKeyword)) {
+        var match = cmdLine.replace(installKeyword + ': ', '');
+        return match;
+      }
+    }    
+  }
+  return '';
 }
 
-var detectMsBuild15Dir = function (pathRoot) {	
   var wherePath = msBuildFromWhere(pathRoot) || '';
   if (wherePath.length > 0) {
-	  return wherePath;
-  }	
+    return wherePath;
   var vs2017Path = path.join(pathRoot, 'Microsoft Visual Studio', '2017');
   var possibleFolders = ['BuildTools', 'Enterprise', 'Professional', 'Community'];
 

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -7,7 +7,43 @@ var fs = require('fs');
 var PluginError = gutil.PluginError;
 var child = require ('child_process');
 
-var detectMsBuild15Dir = function (pathRoot) {
+
+var msBuildFromWhere = function(pathRoot) {	
+	var vsWherePath = path.join(pathRoot, 'Microsoft Visual Studio','Installer', 'vswhere.exe');
+	var whereProcess = child.spawnSync(vsWherePath,
+	{
+		cwd: process.cwd(),
+		env: process.env,
+		stdio: 'pipe',
+		encoding: 'utf-8'
+	});
+	
+	var cmdOutput = '';
+	if (whereProcess.output === null) {
+		return '';
+	}	
+	if (whereProcess.output.length > 0){
+		for (var index = 0; index < whereProcess.output.length; index++) {
+			cmdOutput = whereProcess.output[index] || '';
+			if (cmdOutput.length > 0) {
+				break;
+			}
+		}		
+	}	
+	var installKeyword = 'installationPath';
+	if (cmdOutput.length > 0) {
+		var results = cmdOutput.split(/\r?\n/);
+		var match = results.filter(z => z.startsWith(installKeyword)).shift();
+		return match.replace(`${installKeyword}: `, '');
+	}
+	return ''; 
+}
+
+var detectMsBuild15Dir = function (pathRoot) {	
+  var wherePath = msBuildFromWhere(pathRoot) || '';
+  if (wherePath.length > 0) {
+	  return wherePath;
+  }	
   var vs2017Path = path.join(pathRoot, 'Microsoft Visual Studio', '2017');
   var possibleFolders = ['BuildTools', 'Enterprise', 'Professional', 'Community'];
 

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -44,9 +44,11 @@ var msBuildFromWhere = function(pathRoot) {
   return '';
 }
 
+var detectMsBuild15Dir = function (pathRoot) {
   var wherePath = msBuildFromWhere(pathRoot) || '';
   if (wherePath.length > 0) {
     return wherePath;
+  }
   var vs2017Path = path.join(pathRoot, 'Microsoft Visual Studio', '2017');
   var possibleFolders = ['BuildTools', 'Enterprise', 'Professional', 'Community'];
 

--- a/test/msbuild-finder.js
+++ b/test/msbuild-finder.js
@@ -40,7 +40,7 @@ describe('msbuild-finder', function () {
       expect(result).to.be.equal('xbuild');
     });
   });
-
+  
   it('should use xbuild on darwin', function () {
     var result = msbuildFinder.find({ platform: 'darwin' });
 
@@ -138,30 +138,13 @@ describe('msbuild-finder', function () {
     var toolsVersion = 15.0;
     var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
 
-    var pathRoot = process.env['ProgramFiles'] || path.join('C:', 'Program Files');
-    var vsEnterprisePath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Enterprise');
-    var expectedResult = path.join(vsEnterprisePath, 'MSBuild', '15.0', 'Bin', 'MSBuild.exe');
+    var pathRoot = process.env['ProgramFiles'] || path.join('C:', 'Program Files');	
+    var expectedResult = path.join(pathRoot, 'MSBuild', '15.0', 'Bin', 'MSBuild.exe');
 
     var mock = this.sinon.mock(fs);
-    mock.expects('statSync').withArgs(vsEnterprisePath).returns({});
+    mock.expects('statSync').withArgs(pathRoot).returns({});
 
     var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x86' });
-
-    expect(result).to.be.equal(expectedResult);
-  });
-
-  it('should use visual studio enterprise 64bit msbuild 15 on windows x64 with visual studio 2017 project and visual studio enterprise installed', function () {
-    var toolsVersion = 15.0;
-    var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
-
-    var pathRoot = process.env['ProgramFiles(x86)'] || path.join('C:', 'Program Files (x86)');
-    var vsEnterprisePath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Enterprise');
-    var expectedResult = path.join(vsEnterprisePath, 'MSBuild', '15.0', 'Bin/amd64', 'MSBuild.exe');
-
-    var mock = this.sinon.mock(fs);
-    mock.expects('statSync').withArgs(vsEnterprisePath).returns({});
-
-    var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x64' });
 
     expect(result).to.be.equal(expectedResult);
   });
@@ -184,24 +167,6 @@ describe('msbuild-finder', function () {
     expect(result).to.be.equal(expectedResult);
   });
 
-  it('should use visual studio professional 64bit msbuild 15 on windows x64 with visual studio 2017 project and visual studio professional installed', function () {
-    var toolsVersion = 15.0;
-    var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
-
-    var pathRoot = process.env['ProgramFiles(x86)'] || path.join('C:', 'Program Files (x86)');
-    var vsEnterprisePath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Enterprise');
-    var vsProfessionalPath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Professional');
-    var expectedResult = path.join(vsProfessionalPath, 'MSBuild', '15.0', 'Bin/amd64', 'MSBuild.exe');
-
-    var mock = this.sinon.mock(fs);
-    mock.expects('statSync').withArgs(vsEnterprisePath).throws();
-    mock.expects('statSync').withArgs(vsProfessionalPath).returns({});
-
-    var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x64' });
-
-    expect(result).to.be.equal(expectedResult);
-  });
-
   it('should use visual studio community msbuild 15 on windows with visual studio 2017 project and visual studio community installed', function () {
     var toolsVersion = 15.0;
     var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
@@ -218,26 +183,6 @@ describe('msbuild-finder', function () {
     mock.expects('statSync').withArgs(vsCommunityPath).returns({});
 
     var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x86' });
-
-    expect(result).to.be.equal(expectedResult);
-  });
-
-  it('should use visual studio community 64bit msbuild 15 on windows x64 with visual studio 2017 project and visual studio community installed', function () {
-    var toolsVersion = 15.0;
-    var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
-
-    var pathRoot = process.env['ProgramFiles(x86)'] || path.join('C:', 'Program Files (x86)');
-    var vsEnterprisePath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Enterprise');
-    var vsProfessionalPath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Professional');
-    var vsCommunityPath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Community');
-    var expectedResult = path.join(vsCommunityPath, 'MSBuild', '15.0', 'Bin/amd64', 'MSBuild.exe');
-
-    var mock = this.sinon.mock(fs);
-    mock.expects('statSync').withArgs(vsEnterprisePath).throws();
-    mock.expects('statSync').withArgs(vsProfessionalPath).throws();
-    mock.expects('statSync').withArgs(vsCommunityPath).returns({});
-
-    var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x64' });
 
     expect(result).to.be.equal(expectedResult);
   });
@@ -264,28 +209,6 @@ describe('msbuild-finder', function () {
     expect(result).to.be.equal(expectedResult);
   });
 
-  it('should use visual studio build tools 64bit msbuild 15 on windows x64 with visual studio 2017 project and visual studio build tools installed', function () {
-    var toolsVersion = 15.0;
-    var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
-
-    var pathRoot = process.env['ProgramFiles(x86)'] || path.join('C:', 'Program Files (x86)');
-    var vsEnterprisePath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Enterprise');
-    var vsProfessionalPath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Professional');
-    var vsCommunityPath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Community');
-    var vsBuildToolsPath = path.join(pathRoot, 'Microsoft Visual Studio','2017','BuildTools');
-    var expectedResult = path.join(vsBuildToolsPath, 'MSBuild', '15.0', 'Bin/amd64', 'MSBuild.exe');
-
-    var mock = this.sinon.mock(fs);
-    mock.expects('statSync').withArgs(vsEnterprisePath).throws();
-    mock.expects('statSync').withArgs(vsProfessionalPath).throws();
-    mock.expects('statSync').withArgs(vsCommunityPath).throws();
-    mock.expects('statSync').withArgs(vsBuildToolsPath).returns({});
-
-    var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x64' });
-
-    expect(result).to.be.equal(expectedResult);
-  });
-
   it('should fall back to legacy build path on windows with visual studio 2017 project and visual studio is not installed', function () {
     var toolsVersion = 15.0;
     var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
@@ -304,28 +227,6 @@ describe('msbuild-finder', function () {
     mock.expects('statSync').withArgs(vsBuildToolsPath).throws();
 
     var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x86' });
-
-    expect(result).to.be.equal(expectedResult);
-  });
-
-  it('should fall back to legacy build path on windows x64 with visual studio 2017 project and visual studio is not installed', function () {
-    var toolsVersion = 15.0;
-    var expectMSBuildVersion = constants.MSBUILD_VERSIONS[toolsVersion];
-
-    var pathRoot = process.env['ProgramFiles(x86)'] || path.join('C:', 'Program Files (x86)');
-    var vsEnterprisePath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Enterprise');
-    var vsProfessionalPath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Professional');
-    var vsCommunityPath = path.join(pathRoot, 'Microsoft Visual Studio','2017','Community');
-    var vsBuildToolsPath = path.join(pathRoot, 'Microsoft Visual Studio','2017','BuildTools');
-    var expectedResult = path.join(pathRoot, 'MSBuild', '15.0', 'Bin/amd64', 'MSBuild.exe');
-
-    var mock = this.sinon.mock(fs);
-    mock.expects('statSync').withArgs(vsEnterprisePath).throws();
-    mock.expects('statSync').withArgs(vsProfessionalPath).throws();
-    mock.expects('statSync').withArgs(vsCommunityPath).throws();
-    mock.expects('statSync').withArgs(vsBuildToolsPath).throws();
-
-    var result = msbuildFinder.find({ platform: 'win32', toolsVersion: toolsVersion, architecture: 'x64' });
 
     expect(result).to.be.equal(expectedResult);
   });


### PR DESCRIPTION
It is installed with every version of Visual Studio and this was not working at all for me as I have installed Visual Studio 2017 to a non standard path i.e. D:/Program Files.  This is meant to fix that.

I removed other test cases that are most likely not applicable anymore as vswhere should give the answer on what is installed.

Note that nodejs does not like at all the argument formats '-format json' which I would have preferred to use, but the cmd prompt on Windows is terrible and full of shit.