### PR TITLE
Use msbuild on darwin if present fixes #62

### DIFF
--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -64,7 +64,7 @@ var detectMsBuild15Dir = function (pathRoot) {
 }
 
 // Use MSBuild over XBuild where possible
-var detectLinuxMsBuildExecutable = function () {
+var detectMsBuildOverXBuild = function () {
   try {
     var output = child.spawnSync('which', ['msbuild'], {encoding: 'utf8'});
     if (output.stderr && output.stderr !== 0) {
@@ -116,8 +116,8 @@ var autoDetectVersion = function (pathRoot) {
 };
 
 module.exports.find = function (options) {
-  if (options.platform.match(/linux/)) {
-    var msbuildPath = detectLinuxMsBuildExecutable();
+  if (options.platform.match(/linux|darwin/)) {
+    var msbuildPath = detectMsBuildOverXBuild();
     if (msbuildPath) {
       return msbuildPath;
     }

--- a/test/msbuild-finder.js
+++ b/test/msbuild-finder.js
@@ -40,11 +40,30 @@ describe('msbuild-finder', function () {
       expect(result).to.be.equal('xbuild');
     });
   });
-  
-  it('should use xbuild on darwin', function () {
-    var result = msbuildFinder.find({ platform: 'darwin' });
 
-    expect(result).to.be.equal('xbuild');
+  describe('darwin platorm', function() {
+    var child = require ('child_process');
+
+    it('should use msbuild if possible', function () {
+
+      var mock = this.sinon.mock(child);
+      mock.expects('spawnSync').withArgs('which', ['msbuild'], {encoding: 'utf8'}).returns({});
+
+      var result = msbuildFinder.find({ platform: 'darwin' });
+
+      expect(result).to.be.equal('msbuild');
+    });
+
+    it('should fallback to xbuild when msbuild is not present', function () {
+
+      var mock = this.sinon.mock(child);
+      mock.expects('spawnSync').withArgs('which', ['msbuild'], {encoding: 'utf8'}).returns({
+        stderr: 1
+      });
+
+      var result = msbuildFinder.find({ platform: 'darwin' });
+      expect(result).to.be.equal('xbuild');
+    });
   });
 
   it('should use xbuild on unknown platform', function () {


### PR DESCRIPTION
Coalesced the treatment of linux and darwin (osx) msbuild detection over xbuild if present