### PR TITLE
Using gulp-util templates for logger options too

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ msbuild({ properties: { WarningLevel: 2 } })
 
 **Default:** false -> _Show Startup Banner and Copyright Message_
 
+
 #### fileLoggerParameters
 
 > Specify the parameters for the MSBuild File Logger.
@@ -181,11 +182,15 @@ msbuild({ properties: { WarningLevel: 2 } })
 msbuild({ fileLoggerParameters: 'LogFile=Build.log;Append;Verbosity=diagnostic' })
 ```
 
+**Hint:** Logger parameters options can use ```gulp-util``` templates (e.g. ```"<%= file.path %>"```)
+
 #### consoleLoggerParameters
 
 > Specify the parameters for the MSBuild Console Logger. (See fileLoggerParameters for a usage example)
 
 **Default:** None
+
+**Hint:** Logger parameters options can use ```gulp-util``` templates (e.g. ```"<%= file.path %>"```)
 
 #### loggerParameters
 
@@ -197,6 +202,8 @@ msbuild({ fileLoggerParameters: 'LogFile=Build.log;Append;Verbosity=diagnostic' 
 ```javascript
 msbuild({ loggerParameters: 'XMLLogger,./MyLogger.dll;OutputAsHTML' })
 ```
+
+**Hint:** Logger parameters options can use ```gulp-util``` templates (e.g. ```"<%= file.path %>"```)
 
 #### customArgs
 

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -93,7 +93,7 @@ module.exports.construct = function(file, options) {
 
   var newOptions = _.cloneDeep(options);
 
-  ['consoleLoggerParameters', 'fileLoggerParameters', 'loggerParameters'].forEach(function(prop) {
+  _.intersection(Object.keys(newOptions), ['consoleLoggerParameters', 'fileLoggerParameters', 'loggerParameters']).forEach(function(prop) {
     var context = { file: file };
     newOptions[prop] = gutil.template(newOptions[prop], context);
   });

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -93,6 +93,11 @@ module.exports.construct = function(file, options) {
 
   var newOptions = _.cloneDeep(options);
 
+  ['consoleLoggerParameters', 'fileLoggerParameters', 'loggerParameters'].forEach(function(prop) {
+    var context = { file: file };
+    newOptions[prop] = gutil.template(newOptions[prop], context);
+  });
+
   Object.keys(newOptions.properties).forEach(function(prop) {
     var context = { file: file };
     newOptions.properties[prop] = gutil.template(newOptions.properties[prop], context);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-msbuild",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "msbuild plugin for gulp. Inspired by grunt-msbuild.",
   "keywords": [
     "gulpplugin",

--- a/test/msbuild-command-builder.js
+++ b/test/msbuild-command-builder.js
@@ -231,6 +231,18 @@ describe('msbuild-command-builder', function () {
       expect(result).to.deep.equal(['/target:Rebuild', '/verbosity:normal', '/toolsversion:4.0', '/nologo', '/maxcpucount', '/property:Configuration=Release', '/custom1', '/custom2']);
     });
 
+    it('should parse templates in consoleLoggerParameters, fileLoggerParameters and loggerParameters when specified', function () {
+      var options = defaults;
+      options.consoleLoggerParameters = '<%= (file.path === "test.sln") ? "ErrorsOnly" : "WarningsOnly" %>';
+      options.fileLoggerParameters = 'LogFile=<%= file.path %>.log';
+      options.loggerParameters = 'XMLLogger,<%= (file.path === "test.sln") ? "./TestLogger.dll" : "./MyLogger.dll" %>;OutputAsHTML';
+      var command = commandBuilder.construct({ path: 'test.sln' }, options);
+
+      expect(command.args).to.contain('/clp:ErrorsOnly');
+      expect(command.args).to.contain('/flp:LogFile=test.sln.log');
+      expect(command.args).to.contain('/logger:XMLLogger,./TestLogger.dll;OutputAsHTML');
+    });
+
     it('should parse templates in properties', function () {
       var options = defaults;
       options.properties = { someProp: '<%= file.path %>', anotherProp: 'noTemplate' };


### PR DESCRIPTION
This PR addresses a situation we encountered when you want e.g. to specify a different log filename based on the input solution file, or, in general, manage consoleLoggerOptions, fileLoggerOptions, and loggerOptions based on the file being used at the moment.