### PR TITLE
Support vs2019 msbuild (16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules/
 temp/
 coverage
+.idea
+package-lock.json

--- a/lib/msbuild-command-builder.js
+++ b/lib/msbuild-command-builder.js
@@ -14,6 +14,8 @@ module.exports.buildArguments = function(options) {
     var version = parseFloat(options.toolsVersion).toFixed(1);
     if (isNaN(version)) {
       version = '4.0';
+    } else if (version > 15) {
+      version = 'Current'; // msbuild 16.0 accepts this
     }
     args.push('/toolsversion:' + version);
   }

--- a/lib/msbuild-finder.js
+++ b/lib/msbuild-finder.js
@@ -6,9 +6,12 @@ var constants = require('./constants');
 var fs = require('fs');
 var PluginError = gutil.PluginError;
 var child = require ('child_process');
+var constants = require("./constants");
+var childProcess = require("child_process");
+var os = require("os");
+var lsCache = {};
 
-
-var msBuildFromWhere = function(pathRoot) {
+function msBuildFromWhere(pathRoot) {
   var vsWherePath = path.join(pathRoot, 'Microsoft Visual Studio','Installer', 'vswhere.exe');
   var whereProcess = child.spawnSync(vsWherePath,
     ['-latest', '-products', '*', '-requires', 'Microsoft.Component.MSBuild'],
@@ -20,10 +23,10 @@ var msBuildFromWhere = function(pathRoot) {
     }
   );
 
-  var cmdOutput = '';
   if (whereProcess.output === null) {
     return '';
   }
+  var cmdOutput = '';
   if (whereProcess.output.length > 0){
     for (var index = 0; index < whereProcess.output.length; index++) {
       cmdOutput = whereProcess.output[index] || '';
@@ -46,7 +49,9 @@ var msBuildFromWhere = function(pathRoot) {
   return '';
 }
 
-var detectMsBuild15Dir = function (pathRoot) {
+module.exports.msBuildFromWhere = msBuildFromWhere;
+
+function detectMsBuild15Dir (pathRoot) {
   var wherePath = msBuildFromWhere(pathRoot) || '';
   if (wherePath.length > 0) {
     return wherePath;
@@ -74,20 +79,75 @@ var detectMsBuildOverXBuild = function () {
   } catch (e) {}
 }
 
-var autoDetectVersion = function (pathRoot) {
+function lsR(folder) {
+  if (lsCache[folder]) {
+    return lsCache[folder];
+  }
+  return lsCache[folder] = fs.readdirSync(folder)
+    .reduce((acc, cur) => {
+      var fullPath = path.join(folder, cur);
+      var st = fs.statSync(fullPath);
+      if (st.isFile()) {
+        acc.push(fullPath);
+        return acc;
+      }
+      return acc.concat(lsR(fullPath));
+    }, []);
+}
+
+function findMSBuildExeUnder(folder) {
+  return lsR(folder).filter(fpath => {
+    var fileName = path.basename(fpath);
+    return fileName.toLowerCase() === "msbuild.exe";
+  });
+}
+
+function addDetectedMsBuildVersionsToConstantsLookup(executables) {
+  return executables.map(exe => {
+    try {
+      var proc = childProcess.spawnSync(exe, [ "/version" ], { encoding: "utf8" });
+      var lines = proc.stdout.split(os.EOL);
+      var thisVersion = lines[lines.length - 1];
+      var verParts = thisVersion.split(".");
+      var major = verParts[0];
+      var shortVer = `${major}.0`; // not technically correct: I see msbuild 16.1 on my machine, but keeps in line with prior versioning
+      var ver = parseFloat(shortVer);
+      if (!constants.MSBUILD_VERSIONS[shortVer]) {
+        constants.MSBUILD_VERSIONS[ver] = shortVer;
+        return ver;
+      }
+    } catch (e) {
+      console.warn(`Unable to query version of ${exe}: ${e}`);
+    }
+  })
+  .filter(ver => !!ver)
+  .reduce((acc, cur) => {
+    if (acc.indexOf(cur) === -1) {
+      acc.push(cur);
+    }
+    return acc;
+  }, [])
+  .sort()
+  .reverse();
+}
+
+function autoDetectVersion (pathRoot) {
   // Try to detect MSBuild 15.0.
-  var msbuild15Dir = detectMsBuild15Dir(pathRoot);
-  if (msbuild15Dir) {
-    return [msbuild15Dir, 15.0];
+  var msbuild15OrLaterDir = detectMsBuild15Dir(pathRoot);
+  if (msbuild15OrLaterDir) {
+    var msbuildHome = path.join(msbuild15OrLaterDir, "MSBuild");
+    var msbuildExecutables = findMSBuildExeUnder(msbuildHome);
+    var detected = addDetectedMsBuildVersionsToConstantsLookup(msbuildExecutables);
+    return [msbuild15OrLaterDir, detected[0] || 15.0 ];
   }
 
   // Detect MSBuild lower than 15.0.
   // ported from https://github.com/stevewillcock/grunt-msbuild/blob/master/tasks/msbuild.js#L167-L181
   var msbuildDir = path.join(pathRoot, 'MSBuild');
-  var msbuildDirExists = true;
-
+  var msbuildDirExists;
   try {
     fs.statSync(msbuildDir);
+    msbuildDirExists = true;
   } catch (e) {
     msbuildDirExists = false;
   }
@@ -139,13 +199,22 @@ module.exports.find = function (options) {
     pathRoot = process.env['ProgramFiles'] || 'C:/Program Files';
   }
 
+  // auto-detection also registers higher msbuild versions which from 2019+
+  var shouldProbe = options.toolsVersion === 'auto';
+  if (options.toolsVersion !== 'auto') {
+    var major = parseInt(('' + options.toolsVersion).split('.')[0]);
+    if (!isNaN(major) && major > 15) {
+      shouldProbe = true;
+    }
+  }
+  var auto = shouldProbe ? autoDetectVersion(pathRoot) : null;
   if (options.toolsVersion === 'auto') {
-    var result = autoDetectVersion(pathRoot);
-    msbuildRoot = result[0]
-    options.toolsVersion = result[1];
+    // var result = autoDetectVersion(pathRoot);
+    msbuildRoot = auto[0]
+    options.toolsVersion = auto[1];
   } else {
-    if (options.toolsVersion === 15.0) {
-      var msbuildDir = detectMsBuild15Dir(pathRoot);
+    var msbuildDir = detectMsBuild15Dir(pathRoot);
+    if (options.toolsVersion >= 15.0) {
       if (msbuildDir) {
         msbuildRoot = msbuildDir;
       } else {
@@ -161,7 +230,24 @@ module.exports.find = function (options) {
     throw new PluginError(constants.PLUGIN_NAME, 'No MSBuild Version was supplied!');
   }
 
-  if (version === '12.0' || version === '14.0' || version === '15.0') {
+  var major = parseInt(version.split(".")[0]);
+  if (major > 15) {
+    var x64_dir = is64Bit ? 'amd64' : '';
+    var msbuildHome = path.join(msbuildRoot, 'MSBuild');
+    var msbuildExe = findMSBuildExeUnder(msbuildHome)
+      .filter(exe => {
+        var pathParts = exe.split(path.sep);
+        return is64Bit
+          ? pathParts.indexOf(x64_dir) > -1
+          : pathParts.indexOf(x64_dir) === -1;
+      })[0];
+      if (!msbuildExe) {
+        throw new PluginError(
+          constants.PLUGIN_NAME,
+          `Unable to find msbuild.exe under ${msbuildHome}`);
+      }
+      return msbuildExe;
+  } else if (major >= 12 && major <= 15) {
     var x64_dir = is64Bit ? 'amd64' : '';
     return path.join(msbuildRoot, 'MSBuild', version, 'Bin', x64_dir, 'MSBuild.exe');
   } else {


### PR DESCRIPTION
I've made some logic changes to support vs2019, tested against VS Build Tools 2019. ToolsVersions of 'auto' and 16.0 should select msbuild 16 when installed.

I've also tested with only VS Build Tools 2017 installed, where 'auto' invokes msbuild 15.0

Test-wise, I've added two conditional tests which are only invoked when vs2019 is found on the host machine. I'd prefer to have more "mocked" tests, like the originals but with the auto-detection now also attempting to invoke msbuild to get a version, it's going to take a little more time and effort.

Since the original project is no longer maintained, I'd also like to advocate for me to take over maintenance and package updates, if you're ok with the changes I've made.

I tried to keep the impact I had on these files are minimal as possible, so as to make the PR easier to deal with.